### PR TITLE
[Feat] 인증 샷 삽입/수정/삭제 기능 구현

### DIFF
--- a/Projects/Feature/Sources/ObservedObject/RecordDetailObservedObject.swift
+++ b/Projects/Feature/Sources/ObservedObject/RecordDetailObservedObject.swift
@@ -14,8 +14,6 @@ class RecordDetailObservedObject: ObservableObject {
     @Published var isActionSheetShowing = false
     @Published var showPicker = false
 
-    @Published var certifyingImage: Image = Image("")
-
     // MARK: - Image Picker
 
     enum ImageState {

--- a/Projects/Feature/Sources/ObservedObject/RecordDetailObservedObject.swift
+++ b/Projects/Feature/Sources/ObservedObject/RecordDetailObservedObject.swift
@@ -12,7 +12,7 @@ import PhotosUI
 
 class RecordDetailObservedObject: ObservableObject {
     @Published var isActionSheetShowing = false
-    @Published var showPicker = false
+    @Published var showPhotoPicker = false
 
     // MARK: - Image Picker
 
@@ -32,21 +32,11 @@ class RecordDetailObservedObject: ObservableObject {
 
         static var transferRepresentation: some TransferRepresentation {
             DataRepresentation(importedContentType: .image) { data in
-            #if canImport(AppKit)
-                guard let nsImage = NSImage(data: data) else {
-                    throw TransferError.importFailed
-                }
-                let image = Image(nsImage: nsImage)
-                return ProfileImage(image: image)
-            #elseif canImport(UIKit)
                 guard let uiImage = UIImage(data: data) else {
                     throw TransferError.importFailed
                 }
                 let image = Image(uiImage: uiImage)
                 return CertifyingImage(image: image)
-            #else
-                throw TransferError.importFailed
-            #endif
             }
         }
     }
@@ -76,7 +66,6 @@ class RecordDetailObservedObject: ObservableObject {
                 switch result {
                 case .success(let profileImage?):
                     self.imageState = .success(profileImage.image)
-                    self.certifyingImage = profileImage.image
                 case .success(nil):
                     self.imageState = .empty
                 case .failure(let error):

--- a/Projects/Feature/Sources/ObservedObject/RecordDetailObservedObject.swift
+++ b/Projects/Feature/Sources/ObservedObject/RecordDetailObservedObject.swift
@@ -1,0 +1,90 @@
+//
+//  RecordDetailObservedObject.swift
+//  Feature
+//
+//  Created by 박승찬 on 10/23/23.
+//  Copyright © 2023 com.kozi. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import PhotosUI
+
+class RecordDetailObservedObject: ObservableObject {
+    @Published var isActionSheetShowing = false
+    @Published var showPicker = false
+
+    @Published var certifyingImage: Image = Image("")
+
+    // MARK: - Image Picker
+
+    enum ImageState {
+        case empty
+        case loading(Progress)
+        case success(Image)
+        case failure(Error)
+    }
+
+    enum TransferError: Error {
+        case importFailed
+    }
+
+    struct CertifyingImage: Transferable {
+        let image: Image
+
+        static var transferRepresentation: some TransferRepresentation {
+            DataRepresentation(importedContentType: .image) { data in
+            #if canImport(AppKit)
+                guard let nsImage = NSImage(data: data) else {
+                    throw TransferError.importFailed
+                }
+                let image = Image(nsImage: nsImage)
+                return ProfileImage(image: image)
+            #elseif canImport(UIKit)
+                guard let uiImage = UIImage(data: data) else {
+                    throw TransferError.importFailed
+                }
+                let image = Image(uiImage: uiImage)
+                return CertifyingImage(image: image)
+            #else
+                throw TransferError.importFailed
+            #endif
+            }
+        }
+    }
+
+    @Published private(set) var imageState: ImageState = .empty
+
+    @Published var imageSelection: PhotosPickerItem? {
+        didSet {
+            if let imageSelection {
+                let progress = loadTransferable(from: imageSelection)
+                imageState = .loading(progress)
+            } else {
+                imageState = .empty
+            }
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func loadTransferable(from imageSelection: PhotosPickerItem) -> Progress {
+        return imageSelection.loadTransferable(type: CertifyingImage.self) { result in
+            DispatchQueue.main.async {
+                guard imageSelection == self.imageSelection else {
+                    print("Failed to get the selected item.")
+                    return
+                }
+                switch result {
+                case .success(let profileImage?):
+                    self.imageState = .success(profileImage.image)
+                    self.certifyingImage = profileImage.image
+                case .success(nil):
+                    self.imageState = .empty
+                case .failure(let error):
+                    self.imageState = .failure(error)
+                }
+            }
+        }
+    }
+}

--- a/Projects/Feature/Sources/View/RecordDetailView.swift
+++ b/Projects/Feature/Sources/View/RecordDetailView.swift
@@ -1,0 +1,44 @@
+//
+//  RecordDetailView.swift
+//  Feature
+//
+//  Created by 박승찬 on 2023/10/22.
+//  Copyright © 2023 com.kozi. All rights reserved.
+//
+
+import SwiftUI
+
+struct RecordDetailView: View {
+    @State var isActionSheetShowing = false
+
+    var body: some View {
+        ScrollView {
+            HStack {
+                Text("인증 샷")
+                Spacer()
+            }
+            Button(action: {
+                isActionSheetShowing = true
+            }, label: {
+                Rectangle()
+                    .fill(Color.gray)
+                    .frame(height: 500)
+            })
+            .padding()
+            .confirmationDialog("title", isPresented: $isActionSheetShowing) {
+                Button {
+
+                } label: {
+                    Text("사진 추가")
+                }
+                Button("취소", role: .cancel) {
+                    print("tap cancel")
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    RecordDetailView()
+}

--- a/Projects/Feature/Sources/View/RecordDetailView.swift
+++ b/Projects/Feature/Sources/View/RecordDetailView.swift
@@ -14,12 +14,18 @@ struct RecordDetailView: View {
 
     var body: some View {
         ScrollView {
-            HStack {
-                Text("인증 샷")
-                Spacer()
-            }
-
+            certifyingImageHeader
             CertifyingImageBtn(observedObject: observedObject)
+        }
+    }
+}
+
+extension RecordDetailView {
+    private var certifyingImageHeader: some View {
+        HStack {
+            Text("인증 샷")
+                .padding(.horizontal)
+            Spacer()
         }
     }
 }
@@ -36,15 +42,19 @@ struct CertifyingImageBtn: View {
                 image
                     .resizable()
                     .frame(height: 500)
-                    .frame(maxWidth: .infinity)
                     .scaledToFit()
-
+                    .clipShape(RoundedRectangle(cornerSize: CGSize(width: 4, height: 4)))
             case .loading:
                 ProgressView()
             case .empty:
-                Rectangle()
-                    .frame(height: 500)
-                    .frame(maxWidth: .infinity)
+                ZStack {
+                    RoundedRectangle(cornerSize: CGSize(width: 4, height: 4))
+                        .fill(.gray)
+                        .frame(height: 500)
+                        .frame(maxWidth: .infinity)
+                    Text("오늘의 인증샷을 추가해주세요")
+                        .foregroundStyle(.white)
+                }
             case .failure:
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 40))
@@ -56,13 +66,13 @@ struct CertifyingImageBtn: View {
         .confirmationDialog("title", isPresented: $observedObject.isActionSheetShowing) {
             if observedObject.imageSelection == nil {
                 Button {
-                    observedObject.showPicker.toggle()
+                    observedObject.showPhotoPicker.toggle()
                 } label: {
                     Text("사진 추가")
                 }
             } else {
                 Button {
-                    observedObject.showPicker.toggle()
+                    observedObject.showPhotoPicker.toggle()
                 } label: {
                     Text("사진 수정")
                 }
@@ -75,7 +85,7 @@ struct CertifyingImageBtn: View {
                 print("tap cancel")
             }
         }
-        .photosPicker(isPresented: $observedObject.showPicker, selection: $observedObject.imageSelection)
+        .photosPicker(isPresented: $observedObject.showPhotoPicker, selection: $observedObject.imageSelection)
     }
 }
 

--- a/Projects/Feature/Sources/View/RecordDetailView.swift
+++ b/Projects/Feature/Sources/View/RecordDetailView.swift
@@ -15,7 +15,7 @@ struct RecordDetailView: View {
     var body: some View {
         ScrollView {
             certifyingImageHeader
-            CertifyingImageBtn(observedObject: observedObject)
+            CertifyingImageButton(observedObject: observedObject)
         }
     }
 }
@@ -30,7 +30,7 @@ extension RecordDetailView {
     }
 }
 
-struct CertifyingImageBtn: View {
+struct CertifyingImageButton: View {
     @ObservedObject var observedObject: RecordDetailObservedObject
 
     var body: some View {

--- a/Projects/Feature/Sources/View/RecordDetailView.swift
+++ b/Projects/Feature/Sources/View/RecordDetailView.swift
@@ -11,7 +11,6 @@ import PhotosUI
 
 struct RecordDetailView: View {
     @StateObject var observedObject = RecordDetailObservedObject()
-    @State var showPicker = false
 
     var body: some View {
         ScrollView {

--- a/Projects/Feature/Sources/View/RecordDetailView.swift
+++ b/Projects/Feature/Sources/View/RecordDetailView.swift
@@ -7,10 +7,11 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct RecordDetailView: View {
-    @State var isActionSheetShowing = false
-    @State var certifyingPhoto: String = ""
+    @StateObject var observedObject = RecordDetailObservedObject()
+    @State var showPicker = false
 
     var body: some View {
         ScrollView {
@@ -18,37 +19,90 @@ struct RecordDetailView: View {
                 Text("인증 샷")
                 Spacer()
             }
-            Button(action: {
-                isActionSheetShowing = true
-            }, label: {
+//            Button(action: {
+//                observedObject.isActionSheetShowing = true
+//            }, label: {
+//                Rectangle()
+//                    .fill(Color.gray)
+//                    .frame(height: 500)
+//            })
+//            .padding()
+//            .confirmationDialog("title", isPresented: $observedObject.isActionSheetShowing) {
+//                if observedObject.certifyingPhoto.isEmpty {
+//                    Button {
+//                        observedObject.certifyingPhoto = "사진"
+//                        showPicker.toggle()
+//                    } label: {
+//                        Text("사진 추가")
+//                    }
+//                    PhotosPicker(selection: $observedObject.imageSelection,
+//                                 matching: .images,
+//                                 photoLibrary: .shared()) {
+//                        Text("사진 진짜 추가")
+//                    }
+//                } else {
+//                    Button {
+//                        observedObject.certifyingPhoto = "사진"
+//                    } label: {
+//                        Text("사진 수정")
+//                    }
+//                    Button("사진 삭제", role: .destructive) {
+//                        observedObject.certifyingPhoto = ""
+//                        print("사진 삭제")
+//                    }
+//                }
+//                Button("취소", role: .cancel) {
+//                    print("tap cancel")
+//                }
+//            }
+//            .photosPicker(isPresented: $showPicker, selection: $observedObject.imageSelection)
+
+            CertifyingImageBtn(observedObject: observedObject)
+        }
+    }
+}
+
+struct CertifyingImageBtn: View {
+    @ObservedObject var observedObject: RecordDetailObservedObject
+
+    var body: some View {
+        Button(action: {
+            observedObject.isActionSheetShowing = true
+        }, label: {
+            if observedObject.certifyingImage == Image("") {
                 Rectangle()
                     .fill(Color.gray)
                     .frame(height: 500)
-            })
-            .padding()
-            .confirmationDialog("title", isPresented: $isActionSheetShowing) {
-                if certifyingPhoto.isEmpty {
-                    Button {
-                        certifyingPhoto = "사진"
-                    } label: {
-                        Text("사진 추가")
-                    }
-                } else {
-                    Button {
-                        certifyingPhoto = "사진"
-                    } label: {
-                        Text("사진 수정")
-                    }
-                    Button("사진 삭제", role: .destructive) {
-                        certifyingPhoto = ""
-                        print("사진 삭제")
-                    }
+            } else {
+                observedObject.certifyingImage
+                    .resizable()
+                    .frame(height: 500)
+            }
+        })
+        .padding()
+        .confirmationDialog("title", isPresented: $observedObject.isActionSheetShowing) {
+            if observedObject.certifyingImage == Image("") {
+                Button {
+                    observedObject.showPicker.toggle()
+                } label: {
+                    Text("사진 추가")
                 }
-                Button("취소", role: .cancel) {
-                    print("tap cancel")
+            } else {
+                Button {
+                    observedObject.showPicker.toggle()
+                } label: {
+                    Text("사진 수정")
+                }
+                Button("사진 삭제", role: .destructive) {
+                    observedObject.certifyingImage = Image("")
+                    print("사진 삭제")
                 }
             }
+            Button("취소", role: .cancel) {
+                print("tap cancel")
+            }
         }
+        .photosPicker(isPresented: $observedObject.showPicker, selection: $observedObject.imageSelection)
     }
 }
 

--- a/Projects/Feature/Sources/View/RecordDetailView.swift
+++ b/Projects/Feature/Sources/View/RecordDetailView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct RecordDetailView: View {
     @State var isActionSheetShowing = false
+    @State var certifyingPhoto: String = ""
 
     var body: some View {
         ScrollView {
@@ -26,10 +27,22 @@ struct RecordDetailView: View {
             })
             .padding()
             .confirmationDialog("title", isPresented: $isActionSheetShowing) {
-                Button {
-
-                } label: {
-                    Text("사진 추가")
+                if certifyingPhoto.isEmpty {
+                    Button {
+                        certifyingPhoto = "사진"
+                    } label: {
+                        Text("사진 추가")
+                    }
+                } else {
+                    Button {
+                        certifyingPhoto = "사진"
+                    } label: {
+                        Text("사진 수정")
+                    }
+                    Button("사진 삭제", role: .destructive) {
+                        certifyingPhoto = ""
+                        print("사진 삭제")
+                    }
                 }
                 Button("취소", role: .cancel) {
                     print("tap cancel")

--- a/Projects/Feature/Sources/View/RecordDetailView.swift
+++ b/Projects/Feature/Sources/View/RecordDetailView.swift
@@ -19,43 +19,6 @@ struct RecordDetailView: View {
                 Text("인증 샷")
                 Spacer()
             }
-//            Button(action: {
-//                observedObject.isActionSheetShowing = true
-//            }, label: {
-//                Rectangle()
-//                    .fill(Color.gray)
-//                    .frame(height: 500)
-//            })
-//            .padding()
-//            .confirmationDialog("title", isPresented: $observedObject.isActionSheetShowing) {
-//                if observedObject.certifyingPhoto.isEmpty {
-//                    Button {
-//                        observedObject.certifyingPhoto = "사진"
-//                        showPicker.toggle()
-//                    } label: {
-//                        Text("사진 추가")
-//                    }
-//                    PhotosPicker(selection: $observedObject.imageSelection,
-//                                 matching: .images,
-//                                 photoLibrary: .shared()) {
-//                        Text("사진 진짜 추가")
-//                    }
-//                } else {
-//                    Button {
-//                        observedObject.certifyingPhoto = "사진"
-//                    } label: {
-//                        Text("사진 수정")
-//                    }
-//                    Button("사진 삭제", role: .destructive) {
-//                        observedObject.certifyingPhoto = ""
-//                        print("사진 삭제")
-//                    }
-//                }
-//                Button("취소", role: .cancel) {
-//                    print("tap cancel")
-//                }
-//            }
-//            .photosPicker(isPresented: $showPicker, selection: $observedObject.imageSelection)
 
             CertifyingImageBtn(observedObject: observedObject)
         }
@@ -69,19 +32,30 @@ struct CertifyingImageBtn: View {
         Button(action: {
             observedObject.isActionSheetShowing = true
         }, label: {
-            if observedObject.certifyingImage == Image("") {
-                Rectangle()
-                    .fill(Color.gray)
-                    .frame(height: 500)
-            } else {
-                observedObject.certifyingImage
+            switch observedObject.imageState {
+            case .success(let image):
+                image
                     .resizable()
                     .frame(height: 500)
+                    .frame(maxWidth: .infinity)
+                    .scaledToFit()
+
+            case .loading:
+                ProgressView()
+            case .empty:
+                Rectangle()
+                    .frame(height: 500)
+                    .frame(maxWidth: .infinity)
+            case .failure:
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 40))
+                    .foregroundColor(.white)
             }
+
         })
         .padding()
         .confirmationDialog("title", isPresented: $observedObject.isActionSheetShowing) {
-            if observedObject.certifyingImage == Image("") {
+            if observedObject.imageSelection == nil {
                 Button {
                     observedObject.showPicker.toggle()
                 } label: {
@@ -94,7 +68,7 @@ struct CertifyingImageBtn: View {
                     Text("사진 수정")
                 }
                 Button("사진 삭제", role: .destructive) {
-                    observedObject.certifyingImage = Image("")
+                    observedObject.imageSelection = nil
                     print("사진 삭제")
                 }
             }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
테스트플라이트 배포를 위한 맡은 기능 구현완료 했습니다 :]

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/87136217/dec8ea0a-567c-4da1-a0f7-d5b43b7e7c53" width="130">
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/87136217/eac76a9a-33a7-4d19-aff5-dc94ea6fd136" width="130">
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/87136217/69cdd51f-26d6-4a5c-b842-4793f4c3c88a" width="130">
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/87136217/90d07fff-71f6-4a4d-9ccd-e8c9b3c0920a" width="130">

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 인증 샷 추가, 수정, 삭제를 위해 ActionSheet 추가 및 분기 처리
- 사진 추가, 수정, 삭제 기능

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
Projects/Feature/sources/SwiftUIView.swift 파일 body안에 RecordDetailView() 작성 해주시면 됩니다 :]

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 액션시트 관련해서 ActionSheet라고 생각을 해서 찾아봤는데 ActionSheet는 iOS16을 마지막으로 Deprecated돼서 사용이 불가합니다..
- 좀 더 선언적인 코딩을 하기 위해서 confirmationDialog()를 만들고 사용하게 하기 위함이라고 합니다!

- 뷰 관련해서는 나중에 한번에 darkMode로 설정 해주면 좋을 것 같아서 건들이지 않았습니다!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #5 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- [AppleDeveloper Document_ActionSheet](https://developer.apple.com/documentation/swiftui/actionsheet)
- [AppleDeveloper Document_confirmationdialog()](https://developer.apple.com/documentation/swiftui/view/confirmationdialog(_:ispresented:titlevisibility:presenting:actions:message:)-8y541)
- [AppleDeveloper Document_photosPicker](https://developer.apple.com/documentation/photokit/photospicker)