### PR TITLE
[Feat] 메인 화면 UI 및 기능 구현

### DIFF
--- a/Projects/Feature/Sources/View/MainView.swift
+++ b/Projects/Feature/Sources/View/MainView.swift
@@ -9,8 +9,141 @@
 import SwiftUI
 
 struct MainView: View {
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            ZStack {
+                Color(red: 24 / 255, green: 26 / 255, blue: 31 / 255)
+                    .ignoresSafeArea()
+                VStack {
+                    Image(systemName: "person")
+                        .resizable()
+                        .frame(width: 226, height: 226)
+                        .padding(.top, 50)
+                    userExpSummaryCell
+                }
+                .toolbar {
+                    ToolbarItemGroup(placement: .navigationBarTrailing) {
+                        Menu {
+                            Button("헬스 정보 수정", action: { })
+                            Button("목표 수정", action: { })
+                            Button("앱 설정", action: { })
+                        } label: {
+                            Image(systemName: "person.circle")
+                                .foregroundColor(.white)
+                        }
+                    }
+                }
+                .navigationTitle("기록") // 색상 변경 필요
+            }
+        }
+    }
+
+    var userExpSummaryCell: some View {
+        Rectangle()
+            .foregroundColor(Color(red: 47 / 255, green: 48 / 255, blue: 54 / 255))
+            .cornerRadius(4)
+            .frame(height: 240)
+            .overlay {
+                VStack(spacing: 0) {
+                    NavigationLink {
+                        Text("Hi")
+                    } label: {
+                        HStack(spacing: 0) {
+                            Text("요약")
+                                .fontWeight(.bold)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                        }
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 18)
+                    }
+                    expProgressBar(type: .distanceCovered, value: 80)
+                        .padding(.top, 20)
+                    expProgressBar(type: .calories, value: 40)
+                        .padding(.top, 25)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 60)
+    }
+
+    func expProgressBar(
+        type: ProgressBarType,
+        value: Float
+    ) -> some View {
+
+        var title: String
+        var color: Color
+        var description: String
+
+        switch type {
+        case .distanceCovered:
+            title = "활동량"
+            color = Color(red: 169 / 255, green: 252 / 255, blue: 231 / 255)
+            description = "다음 레벨까지 145KM 남았어요."
+        case .calories:
+            title = "칼로리"
+            color = Color(red: 255 / 255, green: 146 / 255, blue: 165 / 255)
+            description = "다음 레벨까지 60,000Kcal 남았어요."
+        }
+        return VStack(spacing: 0) {
+            ProgressView(value: value, total: 100) {
+                Text(title)
+                    .foregroundColor(.white)
+            }
+            .progressViewStyle(BarProgressStyle(color: color))
+            .frame(height: 44)
+            HStack {
+                Spacer()
+                Text(description)
+                    .font(Font.system(size: 12))
+                    .foregroundStyle(.white)
+            }
+            .frame(height: 22)
+            .padding(.top, 8)
+        }
+        .padding(.horizontal, 18)
+    }
+}
+
+enum ProgressBarType {
+    case distanceCovered
+    case calories
+}
+
+struct BarProgressStyle: ProgressViewStyle {
+
+    var color: Color
+    var height: Double = 10.0
+    var labelFontStyle: Font = .body
+
+    func makeBody(configuration: Configuration) -> some View {
+
+        let progress = configuration.fractionCompleted ?? 0.0
+
+        GeometryReader { geometry in
+            VStack(alignment: .leading) {
+                configuration.label
+                    .font(labelFontStyle)
+                RoundedRectangle(cornerRadius: 8.0)
+                    .fill(Color(uiColor: .darkGray))
+                    .frame(height: height)
+                    .frame(width: geometry.size.width)
+                    .overlay(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 8.0)
+                            .fill(color)
+                            .frame(width: geometry.size.width * progress)
+                            .overlay {
+                                if let currentValueLabel = configuration.currentValueLabel {
+                                    currentValueLabel
+                                        .font(.headline)
+                                        .foregroundColor(.white)
+                                }
+                            }
+                    }
+            }
+        }
     }
 }
 

--- a/Projects/Feature/Sources/View/MainView.swift
+++ b/Projects/Feature/Sources/View/MainView.swift
@@ -1,0 +1,19 @@
+//
+//  MainView.swift
+//  Feature
+//
+//  Created by 한지석 on 10/23/23.
+//  Copyright © 2023 com.kozi. All rights reserved.
+//
+
+import SwiftUI
+
+struct MainView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    MainView()
+}


### PR DESCRIPTION
## 🌁 Background
- 메인 뷰 구현

## 📱 Screenshot
1 | 2
-----|-----
![Simulator Screenshot - iPhone 15 - 2023-10-23 at 16 11 37](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/49385546/321fbc4e-f452-498a-b376-3a30a0987fbd)|![Simulator Screenshot - iPhone 15 - 2023-10-23 at 16 11 35](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/49385546/7a1aec7e-cd40-40a9-adb1-681394f4f4bd)



## 👩‍💻 Contents
- UI 배치 완료(네비게이션 바, 타이틀, 요약 셀)
- 프로그래스바 커스텀 
- 네비게이션 연결

## 📝 Review Note
- 현재는 MainView 내부에 ProgressViewStyle이 구현되어 있는데, 충돌 방지를 위해 머지 이후에 코드 분리 예정입니다.
- 현재는 Mock 데이터와 뷰를 연결하진 않았으나, 이후에 분기처리 되어 있는 곳에 데이터 연결하면 될 것 같습니다.

## 📣 Related Issue
- close #12 