### PR TITLE
[Feat] 기록 요약 UI 구현, Mock 데이터 연결

### DIFF
--- a/Projects/Feature/Sources/ObservedObject/MainDetailViewObservedObject.swift
+++ b/Projects/Feature/Sources/ObservedObject/MainDetailViewObservedObject.swift
@@ -7,3 +7,20 @@
 //
 
 import Foundation
+import SwiftUI
+
+class MainDetailViewObservedObject: ObservableObject {
+    
+    @Published var playerStatistics = PlayerStatistics(totalDistanceCovered: 55,
+                                                       totalCalories: 16500,
+                                                       totalPlayTime: Date(),
+                                                       totalPlay: 11)
+    
+}
+
+struct PlayerStatistics {
+    let totalDistanceCovered: Double
+    let totalCalories: Double
+    let totalPlayTime: Date
+    let totalPlay: Int
+}

--- a/Projects/Feature/Sources/ObservedObject/MainDetailViewObservedObject.swift
+++ b/Projects/Feature/Sources/ObservedObject/MainDetailViewObservedObject.swift
@@ -1,0 +1,9 @@
+//
+//  MainDetailViewObservedObject.swift
+//  Feature
+//
+//  Created by Eojin Choi on 2023/10/24.
+//  Copyright © 2023 com.kozi. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Feature/Sources/View/MainDetailView.swift
+++ b/Projects/Feature/Sources/View/MainDetailView.swift
@@ -1,0 +1,113 @@
+//
+//  MainDetailView.swift
+//  Feature
+//
+//  Created by Eojin Choi on 2023/10/23.
+//  Copyright © 2023 com.kozi. All rights reserved.
+//
+
+import SwiftUI
+
+struct MainDetailView: View {
+    
+    @ObservedObject var observable = MainDetailViewObservedObject()
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(red: 24 / 255, green: 26 / 255, blue: 31 / 255)
+                    .ignoresSafeArea()
+                VStack(spacing: 20) {
+                    userTotalSummaryCell
+                    userLevelSummaryCell
+                    Spacer()
+                }
+                .navigationBarTitle("기록 요약", displayMode: .inline)
+            }
+            .foregroundColor(.white)
+        }
+    }
+
+    
+    var userTotalSummaryCell: some View {
+        Rectangle()
+            .foregroundColor(Color(red: 47 / 255, green: 48 / 255, blue: 54 / 255))
+            .cornerRadius(4)
+            .frame(height: 206)
+            .overlay {
+                VStack(spacing: 0) {
+                    HStack(spacing: 0) {
+                        Text("전체")
+                            .fontWeight(.semibold)
+                        Spacer()
+                    }
+                    .padding(18)
+                    Spacer()
+                    VStack(spacing: 14) {
+                        HStack {
+                            Text("총 활동량")
+                                .font(.system(size: 14))
+                                .fontWeight(.semibold)
+                            Spacer()
+                            Text("\(String(format: "%.0f", observable.playerStatistics.totalDistanceCovered)) KM")
+                                .font(.system(size: 14))
+                        }
+                        HStack {
+                            Text("총 칼로리 소모량")
+                                .font(.system(size: 14))
+                                .fontWeight(.semibold)
+                            Spacer()
+                            Text("\(String(format: "%.0f", observable.playerStatistics.totalCalories)) kcal")
+                                .font(.system(size: 14))
+                        }
+                        HStack {
+                            Text("누적 경기 수")
+                                .font(.system(size: 14))
+                                .fontWeight(.semibold)
+                            Spacer()
+                            Text("\(observable.playerStatistics.totalPlay) 경기")
+                                .font(.system(size: 14))
+                        }
+                        HStack {
+                            Text("누적 플레이 타임")
+                                .font(.system(size: 14))
+                                .fontWeight(.semibold)
+                            Spacer()
+                            Text("21H 32M")
+                                .font(.system(size: 14))
+                        }
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.bottom, 24)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 30)
+    }
+    
+    var userLevelSummaryCell: some View {
+        Rectangle()
+            .foregroundColor(Color(red: 47 / 255, green: 48 / 255, blue: 54 / 255))
+            .cornerRadius(4)
+            .frame(height: 400)
+            .overlay {
+                VStack(spacing: 0) {
+                    HStack(spacing: 0) {
+                        Text("레벨")
+                            .fontWeight(.bold)
+                        Spacer()
+                    }
+                    .padding(18)
+                    VStack {
+                        Spacer()
+                        HStack(spacing: 0) {
+                            Text("좀 더 논의해 봅시다.")
+                                .font(.system(size: 14))
+                        }
+                        Spacer()
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+    }
+}


### PR DESCRIPTION
## 🌁 Background
- 메인 뷰 - 기록 요약 뷰에 대한 UI를 구현한다.

## 📱 Screenshot
<img width='400' src='https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/6462456/374751c4-662c-4fc7-93e4-80e7cef65e02' />

## 👩‍💻 Contents
- `MainDetailView` 생성 및 UI 구현
- `MainDetailViewObservedObject` 및 목업 데이터 생성
- `MainDetailView`와 `MainDetailViewObservedObject` 연결

## 📣 Related Issue
- close #17 
