### PR TITLE
bug: 기록 텝 들어가지지 않는 오류 해결(#42)

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -27,7 +27,9 @@ let infoPlist: [String: Plist.Value] = [
     "CFBundleShortVersionString": "1.0",
     "CFBundleVersion": "1",
     "UIMainStoryboardFile": "",
-    "UILaunchStoryboardName": "LaunchScreen"
+    "UILaunchStoryboardName": "LaunchScreen",
+    "NSHealthShareUsageDescription": "Your workout related data will be used to display your saved workouts in MyWorkouts.",
+    "NSHealthUpdateUsageDescription": "Workouts tracked by MyWorkouts on Apple Watch will be saved to HealthKit."
 ]
 
 let watchTarget = Target(


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
iOS앱에서 기록 탭 들어갈 경우 팅기는 문제 해결을 위한 PR

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="1000" alt="스크린샷 2023-11-01 오후 10 17 33" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/87136217/0bdd1694-a339-469b-8aed-066bf1e418fe">
<img width="1000" alt="스크린샷 2023-11-01 오후 10 17 49" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/87136217/5ca4ae4d-50cc-43a7-ad72-fe26a4477e12">

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- app.plist에 건강 데이터를 share, update하겠다는 auth가 없어서 추가해줬습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
<img width="200" alt="스크린샷 2023-11-01 오후 11 05 12" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-OFO/assets/87136217/676444bb-f950-4a91-ab8e-66eeb7f4d94d">

- 오류 해결하는 도중에 iOS 앱에서 필요없는 물 데이터를 가져오는 것을 확인 했습니다. 
- 이 부분 수정해줘야 할 것 같아요

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #42 
