### PR TITLE
[Chore] Bundle ID, 팀 설정(#47)

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -16,7 +16,7 @@ let watchInfoPlist: [String: Plist.Value] = [
     "UIMainStoryboardFile": "",
     "UILaunchStoryboardName": "LaunchScreen",
     "WKApplication": true,
-    "WKCompanionAppBundleIdentifier": "com.kozi.app",
+    "WKCompanionAppBundleIdentifier": "com.ofo.lockerroom",
     "Required background modes (Watch)": ["Workout Processing"],
     "NSHealthShareUsageDescription": "Your workout related data will be used to display your saved workouts in MyWorkouts.",
     "NSHealthUpdateUsageDescription": "Workouts tracked by MyWorkouts on Apple Watch will be saved to HealthKit."
@@ -36,7 +36,7 @@ let watchTarget = Target(
     name: "WatchExtension_App",
     platform: .watchOS,
     product: .app,
-    bundleId: "com.kozi.app.extension",
+    bundleId: "com.ofo.lockerroom.extension",
     deploymentTarget: .watchOS(targetVersion: "10.0"),
     infoPlist: .extendingDefault(with: watchInfoPlist),
     sources: ["WatchExtension/**"],

--- a/Projects/WatchApp/Project.swift
+++ b/Projects/WatchApp/Project.swift
@@ -16,7 +16,7 @@ let infoPlist: [String: Plist.Value] = [
     "UIMainStoryboardFile": "",
     "UILaunchStoryboardName": "LaunchScreen",
     "WKApplication": true,
-    "WKCompanionAppBundleIdentifier": "com.kozi.watchapp",
+    "WKCompanionAppBundleIdentifier": "com.ofo.watchapp",
     "Required background modes (Watch)": ["Workout Processing"],
     "Privacy - Health Share Usage Description":
         "Your workout related data will be used to display your saved workouts in MyWorkouts.",

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -7,7 +7,7 @@ import ProjectDescription
 
 extension Project {
     
-    private static let organizationName = "com.kozi."
+    private static let organizationName = "com.ofo."
 
     public static func makeModule(
         name: String,
@@ -44,7 +44,7 @@ extension Project {
             name: "\(name)Tests",
             platform: platform,
             product: .unitTests,
-            bundleId: "com.kozi.\(name)Tests",
+            bundleId: "com.ofo.\(name)Tests",
             infoPlist: .default,
             sources: ["Tests/**"],
             dependencies: [
@@ -76,7 +76,7 @@ extension Project {
             name: "WatchApp",
             platform: .watchOS,
             product: .staticFramework,
-            bundleId: "com.kozi.watchTarget.app",
+            bundleId: "com.ofo.watchTarget.app",
             deploymentTarget: .watchOS(targetVersion: "10.0"),
             infoPlist: .extendingDefault(with: infoPlist),
             sources: sources,
@@ -89,7 +89,7 @@ extension Project {
             name: "\(name)Tests",
             platform: .watchOS,
             product: .unitTests,
-            bundleId: "com.kozi.watchTargetTests",
+            bundleId: "com.ofo.watchTargetTests",
             infoPlist: .default,
             sources: ["Tests/**"],
             dependencies: [


### PR DESCRIPTION
## 🌁 Background
- 코지의 계정으로만 빌드되는 현상을 해결합니다.

## 👩‍💻 Contents
 - Apple Connect에서 팀 ofo, 앱 lockerroom 생성 후 팀 초대.
 - tuist - edit을 통해 번들 id com.kozi.app -> com.ofo.lockerroom 으로 변경 및 기타 항목도 마찬가지로 com.ofo로 변경.

## 📣 Related Issue
- 실행이 안될 경우, app target - bundle id - com.kozi.app -> com.ofo.lockerroom 수정이 되어있지 않을 경우,
   확인하시고 수정해주세요!
