### PR TITLE
feat: 기록 시 쓰레기값에 대한 처리(#51)

### DIFF
--- a/Projects/Core/Sources/WorkoutManager.swift
+++ b/Projects/Core/Sources/WorkoutManager.swift
@@ -48,7 +48,7 @@ extension WorkoutManager {
             let sortByStartDate = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
 
             let query = HKSampleQuery(sampleType: .workoutType(),
-                                      predicate: .none, //여기가 언제부터 언제까지 시간에 따른 predicate 이거 바꿔주면 전체 데이터로 가능
+                                      predicate: .none, // 여기가 언제부터 언제까지 시간에 따른 predicate 이거 바꿔주면 전체 데이터로 가능
 //                                      predicate: compoundPredicate,
                                       limit: HKObjectQueryNoLimit,
                                       sortDescriptors: [sortByStartDate]) { (query, samples, error) in
@@ -62,6 +62,18 @@ extension WorkoutManager {
             healthStore.execute(query)
         }
         let workouts = samples as? [HKWorkout]
+
+        var deleteWorkouts = [] as [HKWorkout]
+        if let workoutList = workouts {
+            for workout in workoutList where workout.duration < 20 {
+                deleteWorkouts.append(workout)
+                print("@Log - deleteWorkout : \(workout)")
+            }
+        }
+        healthStore.delete(deleteWorkouts) { success, _ in  // success, error in
+            print("@WorkoutManager_iOS - Delete success? \(success)")
+        }
+
         return workouts == nil ? [] : workouts!
     }
 

--- a/Projects/WatchApp/Sources/Manager/WorkoutManager.swift
+++ b/Projects/WatchApp/Sources/Manager/WorkoutManager.swift
@@ -100,7 +100,7 @@ class WorkoutManager: NSObject, ObservableObject {
 
     func endWorkout() {
         session?.end()
-        showingSummaryView = true
+//        showingSummaryView = true
     }
 
     // MARK: - Workout Metrics
@@ -157,6 +157,12 @@ extension WorkoutManager: HKWorkoutSessionDelegate {
                 self.builder?.finishWorkout { (workout, _) in   // (workout, error) in
                     DispatchQueue.main.async {
                         self.workout = workout // 동작한 workout이 어떤 workout인지 확인하고 파라미터로 받을 수 있습니다.
+                    }
+
+                    if workout?.duration ?? 0 < 20 {
+                        self.resetWorkout()
+                    } else {
+                        self.showingSummaryView = true
                     }
                 }
             }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
애플 워치로 풋살 기록 시 1초, 15초 처럼 짧은 기록, 기록하지 않아도 되는 것들(쓰레기 값)까지 저장하고 보여주는 부분에 대한 처리

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- WatchOS에서는 일정 시간을 넘기지 않을 경우 summary보여주지 않기 (기록이 안된것 처럼 보이기)
- iOS에서 조건(현재는 기록이 20초를 넘기지 않을 경우)에 따라 해당 workout 데이터를 삭제 시켜줍니다.

### Watch⌚️
```swift
builder?.endCollection(withEnd: date) { (_, _) in // 
    self.builder?.finishWorkout { (workout, _) in  

        if workout?.duration ?? 0 < 20 {
            self.resetWorkout()
        } else {
            self.showingSummaryView = true
        }
    }
}
```
### iPhon📱

```swift
healthStore.delete(deleteWorkouts) { success, _ in  
}
```

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- watch에서는 19초, 21초에 기록을 멈춰 보면 테스팅 할 수 있습니다!
- 현재까지는 모든 기록이 record뷰에 기록 될 텐데, pull받으면 20초가 넘지 않는 기록들(쓰레기값)은 모두 지워 지는 것을  확인 할 수 있을거에요!

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 조건 문 작성중에 for in 속에 if문을 넣었다가, for in where문이라는 것을 알게 됐습니다!!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #51 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- [Apple documents_delete(_:withCompletion:)](https://developer.apple.com/documentation/healthkit/hkhealthstore/1614163-delete)